### PR TITLE
Update FriendlyNames.resx

### DIFF
--- a/XenModel/FriendlyNames.resx
+++ b/XenModel/FriendlyNames.resx
@@ -540,6 +540,9 @@
   <data name="Label-host.agentUptime" xml:space="preserve">
     <value>Toolstack uptime</value>
   </data>
+  <data name="Label-host.edition-xcp-ng" xml:space="preserve">
+    <value>XCP-ng Free/Libre Edition</value>
+  </data>  
   <data name="Label-host.edition" xml:space="preserve">
     <value>License</value>
   </data>


### PR DESCRIPTION
This should allow XenCenter to support the new release of XCP-ng